### PR TITLE
Xcode 16 fix: change conflicting method name

### DIFF
--- a/Xcode/Closures/Source/UIControl.swift
+++ b/Xcode/Closures/Source/UIControl.swift
@@ -329,7 +329,7 @@ extension UITextField {
      * returns: itself so you can daisy chain the other event handler calls
      */
     @discardableResult
-    public func onReturn(handler: @escaping () -> Void) -> Self {
+    public func onReturnKeyPress(handler: @escaping () -> Void) -> Self {
         on(.editingDidEndOnExit) { _,_ in
             handler()
         }


### PR DESCRIPTION
With Xcode 16 there is a method `UITextField.onReturn`. It conflicts with method defined in `Closures` with the same signature and crashes Swift compiler. 

A simple workaround is to rename that method.